### PR TITLE
add ARM64 support, platform-aware Makefiles and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,14 @@ bin/spearlet
 *.whl
 *.egg-info
 sdk/python/dist
+sdk/python/build/
+sdk/python/spear/proto/
 __pycache__
 sdk/python/pyproject.toml
+pkg/spear/
+
+# Workload build artifacts / 工作负载构建产物
+workload/docker/python/**/bin/
 
 # Coverage files / 覆盖率文件
 *.profraw

--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ SPEAR is an advanced AI Agent platform designed to support multiple runtime envi
   sh get-docker.sh
   ```
 
+### ARM64 Support
+
+SPEAR binaries and workloads build natively on 64-bit ARM Linux. Install the dependencies listed above using your distribution's ARM64 packages (for Debian/Ubuntu see [`docs/platforms/arm64.md`](docs/platforms/arm64.md)) and use the helper make targets:
+
+- `make spearlet-linux-arm64` to produce a Linux ARM64 spearlet binary (even from non-ARM hosts)
+- `make workload-linux-arm64` to build Docker workloads for `linux/arm64`
+
+Additional cross-compilation notes and troubleshooting tips are collected in [`docs/platforms/arm64.md`](docs/platforms/arm64.md).
+
 ### Build Instructions
 
 To build SPEAR and its related components, run the following command:

--- a/docs/platforms/arm64.md
+++ b/docs/platforms/arm64.md
@@ -1,0 +1,81 @@
+# SPEAR on ARM64
+
+This guide documents host requirements and build tips for running SPEAR on 64-bit ARM hardware such as AWS Graviton, Ampere Altra, and Apple Silicon devices using Linux.
+
+## System dependencies
+
+Most SPEAR runtime components are Go binaries that compile without changes on ARM64. The following native libraries must be available on the host before building:
+
+- `flatbuffers-compiler` (`flatc`) version \>= 24
+- PortAudio development headers: `portaudio19-dev` (or `libportaudio2`)
+- X11 interaction libraries used by automation tooling: `libx11-dev`, `libxtst-dev`, `libxext-dev`
+- Optional audio helpers: `libasound2-dev`
+- Docker Engine 24+ with BuildKit / buildx enabled
+
+On Debian/Ubuntu based distributions:
+
+```bash
+sudo apt-get update
+sudo apt-get install -y \
+  build-essential pkg-config cmake \
+  libx11-dev libxext-dev libxtst-dev \
+  libasound2-dev libportaudio2 portaudio19-dev \
+  flatbuffers-compiler docker.io
+python3 -m pip install --upgrade pip build websocket-client isort
+```
+
+> **Tip:** When running on an ARM Mac with Linux VMs (Multipass, UTM, etc.) ensure virtualization extensions are enabled to run Docker.
+
+## Building SPEAR
+
+1. Generate FlatBuffers bindings and the Go proto package:
+   ```bash
+   make pkg/spear
+   ```
+2. Build the native spearlet binary for your host architecture:
+   ```bash
+   make spearlet
+   ```
+3. To create a Linux ARM64 spearlet from an x86_64 development host, use the new helper target:
+   ```bash
+   make spearlet-linux-arm64
+   ```
+
+The cross-compiled binary is saved under `bin/linux-arm64/spearlet`.
+
+## Workload containers
+
+SPEAR ships Docker-based workloads (Python and Go demo agents). These now respect the `PLATFORM` flag via `DOCKER_DEFAULT_PLATFORM`, enabling reproducible images for both `linux/amd64` and `linux/arm64`.
+
+- Build workloads for the host architecture (default):
+  ```bash
+  make workload
+  ```
+- Build Linux ARM64 workloads on any machine with buildx:
+  ```bash
+  make workload-linux-arm64
+  ```
+- Build Linux AMD64 workloads (useful when developing on ARM hardware but targeting x86):
+  ```bash
+  make workload-linux-amd64
+  ```
+
+Ensure your Docker installation has a builder capable of multi-architecture builds:
+
+```bash
+docker buildx ls | grep -q "linux/arm64" || docker buildx create --use
+```
+
+## Runtime notes
+
+- Vector store helper containers (Qdrant) publish multi-arch images, so no changes are required; Docker will pull the appropriate architecture automatically.
+- Go dependencies such as `portaudio`, `robotgo`, and `kbinani/screenshot` rely on system libraries. When running headless on ARM servers, disable features requiring a GUI by setting the appropriate SPEAR runtime flags.
+- For audio capture on devices without microphone hardware, consider mocking those hostcalls or running in dry-run mode.
+
+## Troubleshooting
+
+- **Missing flatc**: reinstall `flatbuffers-compiler` or build from source following the upstream README.
+- **`docker compose` uses wrong architecture**: confirm `DOCKER_DEFAULT_PLATFORM` is exported or use the make targets above.
+- **CGO cross-compilation errors**: install ARM64 toolchains (`gcc-aarch64-linux-gnu`) when building `spearlet-linux-arm64` on x86_64 hosts.
+
+With these steps, SPEAR should build and run natively on ARM64 hosts as well as produce ARM64 artifacts from other architectures.

--- a/scripts/linux-dep-install.sh
+++ b/scripts/linux-dep-install.sh
@@ -5,30 +5,79 @@ if [ "$EUID" -ne 0 ]; then
     echo "Please run as root"
     exit
 fi
-# install dependencies
+
+set -e
+
+ARCH=$(dpkg --print-architecture 2>/dev/null || uname -m)
+echo "Detected architecture: ${ARCH}"
+
 apt-get update
 
-# install X11 libraries
+# install X11 and audio development libraries
 apt-get install -y \
+    build-essential \
+    cmake dkms \
+    pkg-config \
     libx11-dev \
     libxext-dev \
     libxrender-dev \
     libxtst-dev \
-    pkg-config \
     libasound2-dev \
     libportaudio2 \
     portaudio19-dev \
-    cmake dkms \
-    net-tools isort
+    net-tools
 
-pip install build websocket-client
+PIP_ARGS="--break-system-packages --no-cache-dir"
+python3 -m pip install ${PIP_ARGS} --ignore-installed pip
+python3 -m pip install ${PIP_ARGS} build websocket-client isort
 
-set -e
-# install FlatBuffers
-git clone https://github.com/google/flatbuffers.git
-cd flatbuffers
-cmake -G "Unix Makefiles"
-make -j4 #Compile with 4 threads
-sudo make install #install
-sudo ldconfig #Configuring a dynamic link library
-flatc --version #Check if FlatBuffers is installed successfully
+if ! command -v flatc >/dev/null 2>&1; then
+    case "$ARCH" in
+        amd64|x86_64)
+            echo "Installing flatbuffers-compiler from apt for amd64..."
+            apt-get install -y flatbuffers-compiler
+            ;;
+        arm64|aarch64)
+            echo "Attempting to install flatbuffers-compiler from apt for ARM64..."
+            if ! apt-get install -y flatbuffers-compiler; then
+                echo "Apt installation failed; building FlatBuffers from source for ARM64..."
+                TMP_DIR=$(mktemp -d)
+                git clone https://github.com/google/flatbuffers.git "$TMP_DIR/flatbuffers"
+                pushd "$TMP_DIR/flatbuffers"
+                cmake -G "Unix Makefiles"
+                make -j"$(nproc)"
+                sudo make install
+                sudo ldconfig
+                popd
+                rm -rf "$TMP_DIR"
+            fi
+            ;;
+        *)
+            TMP_DIR=$(mktemp -d)
+            git clone https://github.com/google/flatbuffers.git "$TMP_DIR/flatbuffers"
+            pushd "$TMP_DIR/flatbuffers"
+            cmake -G "Unix Makefiles"
+            make -j"$(nproc)"
+            sudo make install
+            sudo ldconfig
+            popd
+            rm -rf "$TMP_DIR"
+            ;;
+    esac
+fi
+
+# ensure installed flatc supports go module flag (requires >= 23.5)
+if ! flatc --help 2>/dev/null | grep -q -- "--go-module-name"; then
+    echo "Installed flatc lacks --go-module-name; building latest FlatBuffers from source..."
+    TMP_DIR=$(mktemp -d)
+    git clone https://github.com/google/flatbuffers.git "$TMP_DIR/flatbuffers"
+    pushd "$TMP_DIR/flatbuffers"
+    cmake -G "Unix Makefiles"
+    make -j"$(nproc)"
+    sudo make install
+    sudo ldconfig
+    popd
+    rm -rf "$TMP_DIR"
+fi
+
+flatc --version

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 license = { text = "Apache-2.0" }
 requires-python = ">=3.6"
-version = "v0.0.0"
+version = "0.0.5+3.g310d089.dirty"
 
 [project.urls]
 Homepage = "https://github.com/lfedgeai/spear"

--- a/test/test_guide.md
+++ b/test/test_guide.md
@@ -8,12 +8,15 @@ This test document will perform a simple test to verify if the overall architect
   SPEAR relies on some other third-party software dependency packages. To install this packages on Linux, use the following command:
   
   ```bash
-  python -m pip install --upgrade pip
-  pip install build
-  apt install portaudio19-dev libx11-dev libxtst-dev
-  curl -fsSL https://get.docker.com -o get-docker.sh
-  sh get-docker.sh
+  sudo apt-get update
+  sudo apt-get install -y build-essential pkg-config cmake \
+    libx11-dev libxext-dev libxtst-dev \
+    libasound2-dev libportaudio2 portaudio19-dev \
+    flatbuffers-compiler docker.io
+  python3 -m pip install --upgrade pip build websocket-client isort
   ```
+
+For additional notes on ARM64 environments, see [`docs/platforms/arm64.md`](../docs/platforms/arm64.md).
 
 ### Build Instructions
 

--- a/workload/docker/go/gen_image/Makefile
+++ b/workload/docker/go/gen_image/Makefile
@@ -4,8 +4,12 @@ CURRENT_DIR := $(shell pwd)
 OUTPUT_DIR := $(shell pwd)/bin
 PROJ_NAME := $(shell basename $(CURRENT_DIR))
 
+ifdef PLATFORM
+DOCKER_PLATFORM_PREFIX := DOCKER_DEFAULT_PLATFORM=$(PLATFORM) 
+endif
+
 all: build
-	docker compose build --no-cache
+	$(DOCKER_PLATFORM_PREFIX)docker compose build --no-cache
 
 start:
 	CGO_ENABLED=0 GOOS=linux go build -o $(OUTPUT_DIR)/start \

--- a/workload/docker/python/pychat/Makefile
+++ b/workload/docker/python/pychat/Makefile
@@ -4,10 +4,14 @@ PROJ_NAME := $(shell basename $(CURRENT_DIR))
 SDK_OUTPUT_DIR := $(shell pwd)/../../../../sdk/python/dist/
 WHL_FILENAME := $(shell ls $(SDK_OUTPUT_DIR)/../dist/*.whl | xargs basename | tail -n 1)
 
+ifdef PLATFORM
+DOCKER_PLATFORM_PREFIX := DOCKER_DEFAULT_PLATFORM=$(PLATFORM) 
+endif
+
 all: build
 
 build: demo
-	docker compose build --no-cache --build-arg WHL_FILENAME=${WHL_FILENAME}
+	$(DOCKER_PLATFORM_PREFIX)docker compose build --no-cache --build-arg WHL_FILENAME=${WHL_FILENAME}
 
 demo:
 	go build -o $(OUTPUT_DIR)/demo \

--- a/workload/docker/python/pyconversation-local/Makefile
+++ b/workload/docker/python/pyconversation-local/Makefile
@@ -4,10 +4,14 @@ PROJ_NAME := $(shell basename $(CURRENT_DIR))
 SDK_OUTPUT_DIR := $(shell pwd)/../../../../sdk/python/dist/
 WHL_FILENAME := $(shell ls $(SDK_OUTPUT_DIR)/../dist/*.whl | xargs basename | tail -n 1)
 
+ifdef PLATFORM
+DOCKER_PLATFORM_PREFIX := DOCKER_DEFAULT_PLATFORM=$(PLATFORM) 
+endif
+
 all: build
 
 build:
-	docker compose build --no-cache --build-arg WHL_FILENAME=${WHL_FILENAME}
+	$(DOCKER_PLATFORM_PREFIX)docker compose build --no-cache --build-arg WHL_FILENAME=${WHL_FILENAME}
 
 clean:
 	rm -rf $(OUTPUT_DIR)

--- a/workload/docker/python/pydummy/Makefile
+++ b/workload/docker/python/pydummy/Makefile
@@ -4,10 +4,14 @@ PROJ_NAME := $(shell basename $(CURRENT_DIR))
 SDK_OUTPUT_DIR := $(shell pwd)/../../../../sdk/python/dist/
 WHL_FILENAME := $(shell ls $(SDK_OUTPUT_DIR)/../dist/*.whl | xargs basename | tail -n 1)
 
+ifdef PLATFORM
+DOCKER_PLATFORM_PREFIX := DOCKER_DEFAULT_PLATFORM=$(PLATFORM) 
+endif
+
 all: build
 
 build:
-	docker compose build --no-cache --build-arg WHL_FILENAME=${WHL_FILENAME}
+	$(DOCKER_PLATFORM_PREFIX)docker compose build --no-cache --build-arg WHL_FILENAME=${WHL_FILENAME}
 
 clean:
 	rm -rf $(OUTPUT_DIR)

--- a/workload/docker/python/pytest-functionality/Makefile
+++ b/workload/docker/python/pytest-functionality/Makefile
@@ -4,10 +4,14 @@ PROJ_NAME := $(shell basename $(CURRENT_DIR))
 SDK_OUTPUT_DIR := $(shell pwd)/../../../../sdk/python/dist/
 WHL_FILENAME := $(shell ls $(SDK_OUTPUT_DIR)/../dist/*.whl | xargs basename | tail -n 1)
 
+ifdef PLATFORM
+DOCKER_PLATFORM_PREFIX := DOCKER_DEFAULT_PLATFORM=$(PLATFORM) 
+endif
+
 all: build
 
 build:
-	docker compose build --no-cache --build-arg WHL_FILENAME=${WHL_FILENAME}
+	$(DOCKER_PLATFORM_PREFIX)docker compose build --no-cache --build-arg WHL_FILENAME=${WHL_FILENAME}
 
 clean:
 	rm -rf $(OUTPUT_DIR)

--- a/workload/docker/python/pytools/Makefile
+++ b/workload/docker/python/pytools/Makefile
@@ -4,10 +4,14 @@ PROJ_NAME := $(shell basename $(CURRENT_DIR))
 SDK_OUTPUT_DIR := $(shell pwd)/../../../../sdk/python/dist/
 WHL_FILENAME := $(shell ls $(SDK_OUTPUT_DIR)/../dist/*.whl | xargs basename | tail -n 1)
 
+ifdef PLATFORM
+DOCKER_PLATFORM_PREFIX := DOCKER_DEFAULT_PLATFORM=$(PLATFORM) 
+endif
+
 all: build
 
 build: demo
-	docker compose build --no-cache --build-arg WHL_FILENAME=${WHL_FILENAME}
+	$(DOCKER_PLATFORM_PREFIX)docker compose build --no-cache --build-arg WHL_FILENAME=${WHL_FILENAME}
 
 demo:
 	go build -o $(OUTPUT_DIR)/demo \


### PR DESCRIPTION
- add WORKLOAD_PLATFORM and host arch detection to top-level Makefile
- add spearlet-linux-arm64 target and workload-linux-{arm64,amd64} helpers
- propagate PLATFORM -> DOCKER_DEFAULT_PLATFORM in workload Makefiles for multi-arch docker builds
- enhance scripts/linux-dep-install.sh to detect architecture, install flatc via apt or build from source, and use updated pip install args
- add docs/platforms/arm64.md and ARM64 section in README
- update test/test_guide.md with consolidated dependency/install instructions
- update .PHONY and formatting targets to include new targets