### PR TITLE
update readme and environment variable usage

### DIFF
--- a/spear-next/src/sms/config.rs
+++ b/spear-next/src/sms/config.rs
@@ -94,6 +94,20 @@ impl SmsConfig {
         // Start with default configuration / 从默认配置开始
         let mut config = Self::default();
 
+        // Apply environment variables (low priority) / 应用环境变量（较低优先级）
+        // Prefix: SMS_  例如：SMS_GRPC_ADDR, SMS_HTTP_ADDR
+        if let Ok(v) = std::env::var("SMS_GRPC_ADDR") { if let Ok(a) = v.parse::<std::net::SocketAddr>() { config.grpc.addr = a; } }
+        if let Ok(v) = std::env::var("SMS_HTTP_ADDR") { if let Ok(a) = v.parse::<std::net::SocketAddr>() { config.http.addr = a; } }
+        if let Ok(v) = std::env::var("SMS_ENABLE_SWAGGER") { if let Ok(b) = v.parse::<bool>() { config.enable_swagger = b; } }
+
+        if let Ok(v) = std::env::var("SMS_DB_TYPE") { if !v.is_empty() { config.database.db_type = v; } }
+        if let Ok(v) = std::env::var("SMS_DB_PATH") { if !v.is_empty() { config.database.path = v; } }
+        if let Ok(v) = std::env::var("SMS_DB_POOL_SIZE") { if let Ok(n) = v.parse::<u32>() { config.database.pool_size = Some(n); } }
+
+        if let Ok(v) = std::env::var("SMS_LOG_LEVEL") { if !v.is_empty() { config.log.level = v; } }
+        if let Ok(v) = std::env::var("SMS_LOG_FORMAT") { if !v.is_empty() { config.log.format = v; } }
+        if let Ok(v) = std::env::var("SMS_LOG_FILE") { if !v.is_empty() { config.log.file = Some(v); } }
+
         // Try loading from home directory first / 优先从用户主目录加载配置
         // Home path: ~/.sms/config.toml
         // 主目录路径：~/.sms/config.toml
@@ -119,8 +133,7 @@ impl SmsConfig {
             }
         }
 
-        // If home config not found, load from CLI-provided path if any
-        // 如果未找到主目录配置，则从命令行提供的路径加载
+        // Load from CLI-provided path (highest file priority) / 从命令行提供的路径加载（文件最高优先级）
         if let Some(config_path) = &args.config {
             let p = std::path::PathBuf::from(config_path);
             if p.exists() {


### PR DESCRIPTION
This pull request refactors and improves configuration management for both SMS and SPEARlet components, introducing a unified schema and a clear priority order for loading configuration from CLI, home directory, environment variables, and defaults. It also updates documentation and tests to reflect these changes, ensuring that configuration overrides behave as expected.

**Configuration System Improvements**

* Introduced a unified configuration schema for SMS and SPEARlet, with explicit documentation and TOML examples, supporting flexible loading from CLI, home directory, environment variables, and built-in defaults. Updated the configuration priority order and expanded environment variable support for both components in `README.md`.
* Refactored config loading logic in `src/sms/config.rs` and `src/spearlet/config.rs` to apply environment variables with lower priority, load home directory configs first, and allow CLI-provided config files to take highest precedence. [[1]](diffhunk://#diff-ba76d638ef052b1d88539db37757483ba0a0b91446802d1a5a2355a24a037fc2R97-R110) [[2]](diffhunk://#diff-ba76d638ef052b1d88539db37757483ba0a0b91446802d1a5a2355a24a037fc2L122-R136) [[3]](diffhunk://#diff-a6d82a5d570bb367fc280ea73fb103cef38a5bb0f021768fcb03e625c9ac3078R67-R87) [[4]](diffhunk://#diff-a6d82a5d570bb367fc280ea73fb103cef38a5bb0f021768fcb03e625c9ac3078L91-L98)

**Documentation and Project Structure**

* Updated project structure in `README.md` to reflect new config file locations and reorganized source code layout for clarity and maintainability.
* Improved build and run instructions in `README.md`, adding `make` targets for building, testing, and running SMS and SPEARlet.

**Testing Configuration Priority**

* Enhanced and added tests in `src/sms/config_test.rs` and `src/spearlet/config_test.rs` to verify correct precedence of CLI, home, and environment variable overrides, with thorough cleanup to avoid cross-test contamination. [[1]](diffhunk://#diff-2b13ecd394c34c577d766a7c2f4f15e106ea829b38ef38b3f2553c07e2ab1ff9R254-R362) [[2]](diffhunk://#diff-f84bee5b342bf1cd845f0478a82ab2757c91fb90f7d316116bdb345341cca682L326-R464)