### PR TITLE
update docs

### DIFF
--- a/spear-next/.gitignore
+++ b/spear-next/.gitignore
@@ -1,0 +1,5 @@
+ui-tests/node_modules
+ui-tests/test-results
+ui-tests/data
+
+target

--- a/spear-next/README.md
+++ b/spear-next/README.md
@@ -304,6 +304,37 @@ cargo test spearlet_reconnect_tests -- --nocapture
    make run-spearlet
    ```
 
+### Web Admin / 管理页面
+
+- 地址：`http://127.0.0.1:8081/`（启用 `--enable-web-admin` 且指定 `--web-admin-addr`）
+- 功能：节点列表、统计卡片、文件管理、任务管理、设置（主题/时区/Token）
+- 管理 Token：在 Nodes 页工具栏或 Settings 页输入后点击 `Apply` 应用到前端与本地存储
+- 文件页：
+  - `Choose File` 选择文件（美化按钮，旁边显示文件名）
+  - `Upload` 上传到内置对象服务；列表支持下载、复制 URI、删除
+  - URI 形如：`sms+file://<id>`
+- 任务创建：
+  - 可执行类型：`No Executable | Binary | Script | Container | WASM | Process`
+  - Scheme：`sms+file | s3 | minio | https`；选择 `sms+file` 时预填 `sms+file://`
+  - 选择本地 SMS 文件：点击 `Choose Local` 弹窗，`Use` 将 URI 与名称带回表单
+  - 时区：所有时间采用 Settings 页所选时区显示
+
+文档：`ai-docs/web-admin-overview-zh.md`、`ai-docs/web-admin-ui-guide-zh.md`
+
+### UI Tests / 前端测试
+
+- 位置：`spear-next/ui-tests`
+- 框架：Playwright
+- 启动方式：`npm test`（测试会自动启动内置 SMS WebAdmin 服务）
+- 全局初始化：`global-setup.ts` 会清理 `data/files` 目录保证幂等
+- 关键用例：
+  - 任务模态 Scheme 预填与本地文件选择
+  - 可执行类型选择稳定性（使用隐藏原生 `select` 作为测试钩子）
+  - 文件上传、删除及列表刷新
+- 配置：`playwright.config.ts`
+
+文档：`ai-docs/ui-tests-guide-zh.md`
+
 ### E2E Testing / 端到端测试
 
 Container-based E2E tests verify SPEARlet ↔ SMS connectivity using Docker:

--- a/spear-next/ai-docs/INDEX.md
+++ b/spear-next/ai-docs/INDEX.md
@@ -44,6 +44,8 @@
 | HTTP Refactor | [http-refactor-en.md](./http-refactor-en.md) | [http-refactor-zh.md](./http-refactor-zh.md) | HTTP层重构文档 |
 | Handlers Architecture | [handlers-architecture-en.md](./handlers-architecture-en.md) | [handlers-architecture-zh.md](./handlers-architecture-zh.md) | 处理器架构设计 |
 | Handlers to Services Refactor | [handlers-to-services-refactor-en.md](./handlers-to-services-refactor-en.md) | [handlers-to-services-refactor-zh.md](./handlers-to-services-refactor-zh.md) | 处理器到服务重构 |
+| Web Admin Overview | [web-admin-overview-en.md](./web-admin-overview-en.md) | [web-admin-overview-zh.md](./web-admin-overview-zh.md) | 管理页面概览 |
+| Web Admin UI Guide | [web-admin-ui-guide-en.md](./web-admin-ui-guide-en.md) | [web-admin-ui-guide-zh.md](./web-admin-ui-guide-zh.md) | 管理页面交互与使用指南 |
 
 ### 🔌 gRPC Layer / gRPC层
 
@@ -85,6 +87,7 @@
 | Code Cleanup | [code-cleanup-en.md](./code-cleanup-en.md) | [code-cleanup-zh.md](./code-cleanup-zh.md) | 代码清理文档 |
 | Code Cleanup Summary | [code-cleanup-summary-en.md](./code-cleanup-summary-en.md) | [code-cleanup-summary-zh.md](./code-cleanup-summary-zh.md) | 代码清理摘要 |
 | File Cleanup Summary | [file-cleanup-summary-en.md](./file-cleanup-summary-en.md) | [file-cleanup-summary-zh.md](./file-cleanup-summary-zh.md) | 文件清理摘要 |
+| UI Tests Guide | [ui-tests-guide-en.md](./ui-tests-guide-en.md) | [ui-tests-guide-zh.md](./ui-tests-guide-zh.md) | 前端UI测试使用指南 |
 
 ### 📝 Code Examples / 代码示例
 

--- a/spear-next/ai-docs/ui-tests-guide-en.md
+++ b/spear-next/ai-docs/ui-tests-guide-en.md
@@ -1,0 +1,36 @@
+# Frontend UI Tests (Playwright)
+
+## Location & Run
+
+- Directory: `spear-next/ui-tests`
+- Run: `npm test`
+- Tests compile and run the embedded SMS with WebAdmin at `127.0.0.1:8081`
+
+## Global Setup
+
+- `global-setup.ts` cleans `data/files` before each run to ensure deterministic file list, upload, and delete tests
+
+## Key Specs
+
+- `task_modal.spec.ts`: select `sms+file`, click `Use` in picker to fill URI
+- `task_modal_scheme_prefill.spec.ts`: scheme selection pre-fills `Executable URI`
+- `executable_select_unit.spec.ts`: uses hidden native `select` for stable type selection
+- `files.spec.ts`: upload a small file and copy URI
+- `files_delete.spec.ts`: delete a file and verify the list updates
+- `files_modified_tz.spec.ts`: human-readable timestamps in selected timezone
+
+## Environment
+
+- Playwright config: `playwright.config.ts`
+- Browser: Chromium by default (configurable)
+
+## Notes
+
+- Dropdown stability: tests use a native `select` mirror to avoid portal positioning flakiness
+- Delete verification: prefer row-matching and message assertion over global row counts
+
+## CI
+
+- Can run in CI; refer to `ui-tests/package.json` scripts
+- Logs and artifacts: failed runs produce context files under `test-results`
+

--- a/spear-next/ai-docs/ui-tests-guide-zh.md
+++ b/spear-next/ai-docs/ui-tests-guide-zh.md
@@ -1,0 +1,36 @@
+# 前端 UI 测试指南（Playwright）
+
+## 位置与启动
+
+- 目录：`spear-next/ui-tests`
+- 启动：`npm test`
+- 测试会自动编译并运行内置 SMS（启用 WebAdmin），地址 `127.0.0.1:8081`
+
+## 全局初始化
+
+- `global-setup.ts` 在每次测试前清理 `data/files`，保证列表、上传、删除用例的幂等性
+
+## 关键用例
+
+- `task_modal.spec.ts`：选择 `sms+file`，在弹窗中点击 `Use` 填充 URI
+- `task_modal_scheme_prefill.spec.ts`：切换 Scheme 自动预填 `Executable URI`
+- `executable_select_unit.spec.ts`：使用隐藏原生 `select` 钩子验证类型选择（稳定，不受弹层干扰）
+- `files.spec.ts`：上传文件并复制 URI
+- `files_delete.spec.ts`：删除文件并校验列表变化
+- `files_modified_tz.spec.ts`：按设置的时区显示人类可读时间
+
+## 运行环境
+
+- Playwright 配置：`playwright.config.ts`
+- 浏览器：默认使用 Chromium（可在配置中调整）
+
+## 常见问题
+
+- 下拉选择不稳定：通过隐藏原生 `select` 作为测试入口，避免 Antd 弹层选择的定位波动
+- 删除校验：优先通过提示与行匹配校验，减少依赖全局行计数
+
+## 提示
+
+- 可在 CI 中运行：结合 `ui-tests/package.json` 脚本
+- 日志与截图：Playwright 默认在失败时生成上下文文件，可在 `test-results` 查看
+

--- a/spear-next/ai-docs/web-admin-ui-guide-en.md
+++ b/spear-next/ai-docs/web-admin-ui-guide-en.md
@@ -1,0 +1,54 @@
+# Web Admin UI Guide
+
+This document explains how to use the `spear-next` Web Admin, covering nodes, files, and task creation.
+
+## Access & Auth
+
+- Enable: run SMS with `--enable-web-admin --web-admin-addr 127.0.0.1:8081`
+- URL: `http://127.0.0.1:8081/`
+- Admin Token:
+  - Enter in Nodes toolbar or Settings page and click `Apply`
+  - Token is stored in `window.__ADMIN_TOKEN` and `localStorage('ADMIN_TOKEN')`
+
+## Top Settings
+
+- Theme: dark/light using Ant Design theme algorithms
+- Timezone: all timestamps render using the selected timezone
+
+## Nodes
+
+- List supports search, time sorting, pagination, and details modal
+- SSE: backend `GET /admin/api/nodes/stream` for live updates
+- Toolbar includes search, sort, Admin Token input, and `Apply Token` button
+
+## Files
+
+- Choose File: click the `Choose File` button (hidden native `<input type="file">` triggered)
+- Upload: click `Upload`; success toast shows `Uploaded: <id>`
+- Actions:
+  - `Download` the object
+  - `Copy URI` copies `sms+file://<id>`
+  - `Delete` removes and refreshes list (React Query invalidate + local filter)
+
+## Task Creation (Tasks → Create Task)
+
+- Executable type: `No Executable | Binary | Script | Container | WASM | Process`
+- Scheme options: `sms+file | s3 | minio | https`
+  - Selecting `sms+file` pre-fills `sms+file://`
+  - Switching from non-`sms+file` back will not reset to placeholder
+- Choose Local SMS File:
+  - Click `Choose Local` to open the picker
+  - Click `Use` to set `Executable URI = sms+file://<id>` and `Executable Name`
+- Parameters: `Capabilities` (comma), `Args` (comma), `Env` (`key=value` per line)
+
+## Known Issues & Fixes
+
+- Always-open dropdown: removed forced `open`; default interaction restored
+- Scheme reset: only updates from URI when `://` is present; `sms+file` pre-fills
+- Picker width: fixed modal width and column widths with ellipsis
+
+## Related Docs
+
+- `ai-docs/web-admin-overview-en.md`
+- `ai-docs/ui-tests-guide-en.md`
+

--- a/spear-next/ai-docs/web-admin-ui-guide-zh.md
+++ b/spear-next/ai-docs/web-admin-ui-guide-zh.md
@@ -1,0 +1,54 @@
+# Web 管理页面使用指南
+
+本文介绍 `spear-next` 管理页面的实际使用与交互细节，覆盖节点、文件与任务创建等功能。
+
+## 访问与鉴权
+
+- 启用：运行 SMS 时添加 `--enable-web-admin --web-admin-addr 127.0.0.1:8081`
+- 地址：`http://127.0.0.1:8081/`
+- 管理 Token：
+  - Nodes 页工具栏或 Settings 页输入 Token 并点击 `Apply`
+  - Token 会写入 `window.__ADMIN_TOKEN` 与 `localStorage('ADMIN_TOKEN')`
+
+## 顶部设置
+
+- 主题：暗/亮切换使用 Ant Design 主题算法，所有控件自动适配
+- 时区：设置页选择后，页面所有时间按所选时区显示（包括任务与文件）
+
+## 节点（Nodes）
+
+- 列表支持搜索、按时间排序、分页与详情弹窗
+- SSE：后端 `GET /admin/api/nodes/stream`，用于实时刷新统计与列表
+- 工具栏：包含搜索框、排序选择、Admin Token 输入框与 `Apply Token` 按钮
+
+## 文件（Files）
+
+- 选择文件：点击 `Choose File` 打开系统文件选择器（隐藏原生 `<input type="file">`，前端使用按钮触发）
+- 上传：点击 `Upload` 上传到内置对象服务；成功后收到 `Uploaded: <id>` 提示
+- 列表操作：
+  - `Download`：直接下载
+  - `Copy URI`：复制 `sms+file://<id>` 到剪贴板
+  - `Delete`：删除后立即刷新（React Query 失效+本地过滤）
+
+## 任务创建（Tasks → Create Task）
+
+- 可执行类型：`No Executable | Binary | Script | Container | WASM | Process`
+- Scheme：`sms+file | s3 | minio | https`
+  - 切到 `sms+file` 会自动预填 `sms+file://`
+  - 从非 `sms+file` 切回时不会重置为占位项
+- 选择本地 SMS 文件：
+  - 点击 `Choose Local` 打开文件选择弹窗
+  - 点击 `Use` 将 `Executable URI = sms+file://<id>` 与 `Executable Name` 带回表单
+- 参数：`Capabilities`（逗号分隔）、`Args`（逗号分隔）、`Env`（每行 `key=value`）
+
+## 常见问题
+
+- 下拉长期悬浮：已移除强制 `open`，恢复默认交互
+- Scheme 重置：当 URI 不包含 `://` 不再重置；`sms+file` 会预填 `sms+file://`
+- 文件对话框溢出：设置了固定宽度与列宽，长文本省略显示
+
+## 相关文档
+
+- `ai-docs/web-admin-overview-zh.md`
+- `ai-docs/ui-tests-guide-zh.md`
+


### PR DESCRIPTION
This pull request enhances documentation and developer experience for the Web Admin and UI testing features in the `spear-next` project. It introduces comprehensive guides for the Web Admin UI and frontend Playwright tests, updates the documentation index for easier navigation, and improves `.gitignore` coverage for test artifacts.

**Documentation Improvements**

* Added detailed guides for Web Admin UI usage (`ai-docs/web-admin-ui-guide-en.md`, `ai-docs/web-admin-ui-guide-zh.md`), covering access, authentication, node and file management, task creation, settings, and known UI issues. [[1]](diffhunk://#diff-7c8443429d301bcdc34274a5668e7c19b84a5a9a86ad761dca2403d1ed4ac5f4R1-R54) [[2]](diffhunk://#diff-3bbef9c33c85123c9b1bcd8e5760be2fbd12972880e8ba69d5fb408d3f24c931R1-R54)
* Added frontend UI test guides for Playwright in both English and Chinese (`ai-docs/ui-tests-guide-en.md`, `ai-docs/ui-tests-guide-zh.md`), describing test locations, setup, key scenarios, environment, and CI integration. [[1]](diffhunk://#diff-d22c4e446a274ea8b5af1c1b4f0b90142c303d64d5531ed1b32345db6be9183dR1-R36) [[2]](diffhunk://#diff-335361fdcb2519cd7e2f7ed0812a897d4958df1eafec99c7e885689ffb47a36cR1-R36)
* Updated the documentation index (`ai-docs/INDEX.md`) to include links to the new Web Admin overview, UI guide, and UI tests guide for both languages. [[1]](diffhunk://#diff-074474c851843bebfd61cc0dc6b45301f0aa4b921371bb48ca2f63cc22fab4c5R47-R48) [[2]](diffhunk://#diff-074474c851843bebfd61cc0dc6b45301f0aa4b921371bb48ca2f63cc22fab4c5R90)

**Developer Experience**

* Expanded `.gitignore` to exclude Playwright test artifacts and build targets, preventing accidental commits of test data and results.

**User-Facing Documentation**

* Updated the main `README.md` to describe the Web Admin features and UI tests, providing quick access and summary for new users and contributors.