### PR TITLE
add task event support

### DIFF
--- a/spear-next/config/sms/config-rocksdb.toml
+++ b/spear-next/config/sms/config-rocksdb.toml
@@ -20,3 +20,7 @@ enable_tls = false
 db_type = "rocksdb"
 path = "./data/rocksdb-node-service"
 pool_size = 10
+
+[event_kv]
+backend = "rocksdb"
+params = { path = "./data/events-rocksdb" }

--- a/spear-next/config/sms/config-sled.toml
+++ b/spear-next/config/sms/config-sled.toml
@@ -20,3 +20,7 @@ enable_tls = false
 db_type = "sled"
 path = "./data/node-service.db"
 pool_size = 10
+
+[event_kv]
+backend = "sled"
+params = { path = "./data/events-sled.db" }

--- a/spear-next/config/sms/config.toml
+++ b/spear-next/config/sms/config.toml
@@ -40,6 +40,10 @@ path = "./data/sms.db"
 # Connection pool size / 连接池大小
 pool_size = 10
 
+[event_kv]
+backend = "memory"
+params = {}
+
 [log]
 # Log level: trace/debug/info/warn/error / 日志级别
 level = "debug"

--- a/spear-next/config/sms/example-config.toml
+++ b/spear-next/config/sms/example-config.toml
@@ -20,3 +20,7 @@ enable_tls = false
 db_type = "sled"
 path = "./data/sms"
 pool_size = 10
+
+[event_kv]
+backend = "sled"
+params = { path = "./data/events" }

--- a/spear-next/proto/sms/task.proto
+++ b/spear-next/proto/sms/task.proto
@@ -80,6 +80,32 @@ message RegisterTaskResponse {
   Task task = 4;                         // Registered task details / 注册的任务详情
 }
 
+// Task event kind / 任务事件类型
+enum TaskEventKind {
+  TASK_EVENT_KIND_UNKNOWN = 0;
+  TASK_EVENT_KIND_CREATE = 1;
+  TASK_EVENT_KIND_UPDATE = 2;
+  TASK_EVENT_KIND_CANCEL = 3;
+}
+
+// Task event for subscription / 任务事件（用于订阅）
+message TaskEvent {
+  int64 event_id = 1;           // Monotonic event id per node / 每节点单调递增事件ID
+  int64 ts = 2;                 // Event timestamp (epoch seconds) / 事件时间戳
+  string node_uuid = 3;         // Target node UUID / 目标节点UUID
+  string task_id = 4;           // Task ID / 任务ID
+  TaskEventKind kind = 5;       // Event kind / 事件类型
+}
+
+// Subscribe request with optional resume position / 订阅请求（可带断点续传位置）
+message SubscribeTaskEventsRequest {
+  string node_uuid = 1;         // Node UUID to subscribe / 订阅的节点UUID
+  int64 last_event_id = 2;      // Last processed id to resume from / 已处理的最后事件ID（从此之后恢复）
+}
+
+// Ack response / 确认响应
+message AckResponse { bool ok = 1; }
+
 // List tasks request / 列出任务请求
 message ListTasksRequest {
   string node_uuid = 1;                  // Filter by node UUID (optional) / 按节点UUID过滤（可选）
@@ -132,4 +158,7 @@ service TaskService {
   
   // Unregister a task / 注销任务
   rpc UnregisterTask(UnregisterTaskRequest) returns (UnregisterTaskResponse);
+
+  // Subscribe task events for a node / 订阅节点任务事件
+  rpc SubscribeTaskEvents(SubscribeTaskEventsRequest) returns (stream TaskEvent);
 }

--- a/spear-next/src/apps/spearlet/main.rs
+++ b/spear-next/src/apps/spearlet/main.rs
@@ -73,6 +73,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             return Err(Box::<dyn std::error::Error + Send + Sync>::from(e));
         }
         tracing::info!("Registration service started (heartbeat every {}s)", config.heartbeat_interval);
+        let subscriber = spear_next::spearlet::task_events::TaskEventSubscriber::new(config.clone());
+        subscriber.start().await;
     }
     
     // Wait for shutdown signal / 等待关闭信号

--- a/spear-next/src/config/mod.rs
+++ b/spear-next/src/config/mod.rs
@@ -25,6 +25,7 @@ use std::path::PathBuf;
 /// Base configuration shared by all applications / 所有应用程序共享的基础配置
 pub mod base;
 pub use base::*;
+pub use crate::storage::kv::KvStoreConfig;
 
 /// Base configuration trait / 基础配置特征
 /// All application configurations should implement this trait

--- a/spear-next/src/sms/events.rs
+++ b/spear-next/src/sms/events.rs
@@ -1,0 +1,94 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+
+use crate::proto::sms::{Task, TaskEvent, TaskEventKind};
+use tracing::{debug, warn};
+use crate::sms::services::error::SmsError;
+use crate::storage::kv::{KvStore, KvPair, serialization};
+
+const OUTBOX_PREFIX: &str = "task_events:"; // key: task_events:{node_uuid}:{event_id}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+struct StoredEvent { event_id: i64, ts: i64, node_uuid: String, task_id: String, kind: i32 }
+
+#[derive(Debug, Clone)]
+pub struct TaskEventBus {
+    kv: Arc<dyn KvStore>,
+    channels: Arc<tokio::sync::RwLock<HashMap<String, broadcast::Sender<TaskEvent>>>>,
+    counters: Arc<tokio::sync::RwLock<HashMap<String, i64>>>,
+}
+
+impl TaskEventBus {
+    pub fn new(kv: Arc<dyn KvStore>) -> Self {
+        Self { kv, channels: Arc::new(tokio::sync::RwLock::new(HashMap::new())), counters: Arc::new(tokio::sync::RwLock::new(HashMap::new())) }
+    }
+
+    async fn next_id(&self, node_uuid: &str) -> i64 {
+        let mut map = self.counters.write().await;
+        let e = map.entry(node_uuid.to_string()).or_insert(0);
+        *e += 1;
+        *e
+    }
+
+    async fn get_sender(&self, node_uuid: &str) -> broadcast::Sender<TaskEvent> {
+        let mut chans = self.channels.write().await;
+        if let Some(tx) = chans.get(node_uuid) { return tx.clone(); }
+        let (tx, _rx) = broadcast::channel(1024);
+        chans.insert(node_uuid.to_string(), tx.clone());
+        tx
+    }
+
+    pub async fn subscribe(&self, node_uuid: &str) -> broadcast::Receiver<TaskEvent> {
+        let tx = self.get_sender(node_uuid).await;
+        tx.subscribe()
+    }
+
+    pub async fn replay_since(&self, node_uuid: &str, last_event_id: i64, limit: usize) -> Result<Vec<TaskEvent>, SmsError> {
+        debug!(node_uuid = %node_uuid, last_event_id, limit, "Replaying task events");
+        let prefix = format!("{}{}:", OUTBOX_PREFIX, node_uuid);
+        let all = self.kv.scan_prefix(&prefix).await?;
+        let mut events: Vec<TaskEvent> = Vec::new();
+        for KvPair{key, value} in all.into_iter() {
+            if let Some(id_str) = key.strip_prefix(&prefix) {
+                if let Ok(id) = id_str.parse::<i64>() {
+                    if id > last_event_id {
+                        let se: StoredEvent = serialization::deserialize(&value)?;
+                        let ev = TaskEvent { event_id: se.event_id, ts: se.ts, node_uuid: se.node_uuid, task_id: se.task_id, kind: se.kind };
+                        events.push(ev);
+                    }
+                }
+            }
+        }
+        events.sort_by_key(|e| e.event_id);
+        debug!(count = events.len(), "Replay collected events");
+        if events.len() > limit { events.truncate(limit); }
+        Ok(events)
+    }
+
+    pub async fn publish_create(&self, task: &Task) -> Result<TaskEvent, SmsError> {
+        self.publish(task, TaskEventKind::Create).await
+    }
+
+    pub async fn publish_update(&self, task: &Task) -> Result<TaskEvent, SmsError> {
+        self.publish(task, TaskEventKind::Update).await
+    }
+
+    pub async fn publish_cancel(&self, task: &Task) -> Result<TaskEvent, SmsError> {
+        self.publish(task, TaskEventKind::Cancel).await
+    }
+
+    async fn publish(&self, task: &Task, kind: TaskEventKind) -> Result<TaskEvent, SmsError> {
+        let node_uuid = task.node_uuid.clone();
+        let id = self.next_id(&node_uuid).await;
+        let ev = TaskEvent { event_id: id, ts: chrono::Utc::now().timestamp(), node_uuid: node_uuid.clone(), task_id: task.task_id.clone(), kind: kind as i32 };
+        let key = format!("{}{}:{}", OUTBOX_PREFIX, node_uuid, id);
+        let se = StoredEvent { event_id: ev.event_id, ts: ev.ts, node_uuid: ev.node_uuid.clone(), task_id: ev.task_id.clone(), kind: ev.kind };
+        let val = serialization::serialize(&se)?;
+        self.kv.put(&key, &val).await?;
+        debug!(node_uuid = %node_uuid, event_id = id, kind = ev.kind, task_id = %ev.task_id, "Published task event to KV and broadcasting");
+        let tx = self.get_sender(&node_uuid).await;
+        if let Err(e) = tx.send(ev.clone()) { warn!(error = %e, "Broadcast send failed"); }
+        Ok(ev)
+    }
+}

--- a/spear-next/src/sms/events_test.rs
+++ b/spear-next/src/sms/events_test.rs
@@ -1,0 +1,60 @@
+#[cfg(test)]
+mod tests {
+    use super::super::events::TaskEventBus;
+    use crate::storage::kv::MemoryKvStore;
+    use std::sync::Arc;
+    use crate::proto::sms::{Task, TaskStatus, TaskPriority};
+
+    fn sample_task(node_uuid: &str, name: &str) -> Task {
+        Task {
+            task_id: uuid::Uuid::new_v4().to_string(),
+            name: name.to_string(),
+            description: "".to_string(),
+            status: TaskStatus::Registered as i32,
+            priority: TaskPriority::Normal as i32,
+            node_uuid: node_uuid.to_string(),
+            endpoint: "".to_string(),
+            version: "v1".to_string(),
+            capabilities: vec![],
+            registered_at: chrono::Utc::now().timestamp(),
+            last_heartbeat: chrono::Utc::now().timestamp(),
+            metadata: Default::default(),
+            config: Default::default(),
+            executable: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_publish_and_subscribe() {
+        let kv: Arc<dyn crate::storage::kv::KvStore> = Arc::new(MemoryKvStore::new());
+        let bus = TaskEventBus::new(kv);
+
+        let node_uuid = uuid::Uuid::new_v4().to_string();
+        let mut rx = bus.subscribe(&node_uuid).await;
+
+        let t = sample_task(&node_uuid, "t1");
+        let ev = bus.publish_create(&t).await.unwrap();
+
+        let recv = rx.recv().await.unwrap();
+        assert_eq!(recv.task_id, t.task_id);
+        assert_eq!(recv.event_id, ev.event_id);
+        assert_eq!(recv.node_uuid, node_uuid);
+    }
+
+    #[tokio::test]
+    async fn test_durable_replay_since() {
+        let kv: Arc<dyn crate::storage::kv::KvStore> = Arc::new(MemoryKvStore::new());
+        let bus = TaskEventBus::new(kv);
+        let node_uuid = uuid::Uuid::new_v4().to_string();
+        let t1 = sample_task(&node_uuid, "t1");
+        let e1 = bus.publish_create(&t1).await.unwrap();
+        let t2 = sample_task(&node_uuid, "t2");
+        let e2 = bus.publish_create(&t2).await.unwrap();
+
+        let replay = bus.replay_since(&node_uuid, e1.event_id, 100).await.unwrap();
+        assert_eq!(replay.len(), 1);
+        assert_eq!(replay[0].event_id, e2.event_id);
+        assert_eq!(replay[0].task_id, t2.task_id);
+    }
+}
+

--- a/spear-next/src/sms/mod.rs
+++ b/spear-next/src/sms/mod.rs
@@ -46,6 +46,7 @@ pub mod grpc_server;
 pub mod http_gateway;
 pub mod web_admin;
 pub mod service;
+pub mod events;
 pub mod gateway;
 pub mod routes;
 
@@ -63,6 +64,8 @@ pub mod routes_test;
 pub mod gateway_test;
 #[cfg(test)]
 pub mod file_service_test;
+#[cfg(test)]
+pub mod events_test;
 
 // Re-export commonly used types / 重新导出常用类型
 pub use types::*;

--- a/spear-next/src/sms/service_event_kv_test.rs
+++ b/spear-next/src/sms/service_event_kv_test.rs
@@ -1,0 +1,102 @@
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use tokio_stream::StreamExt;
+    use tonic::Request;
+
+    use crate::sms::service::SmsServiceImpl;
+    use crate::sms::services::{node_service::NodeService, resource_service::ResourceService};
+    use crate::sms::config::SmsConfig;
+    use crate::storage::kv::KvStoreConfig;
+    use crate::proto::sms::{RegisterTaskRequest, SubscribeTaskEventsRequest};
+
+    fn make_request(node_uuid: &str) -> RegisterTaskRequest {
+        RegisterTaskRequest {
+            name: "t".to_string(),
+            description: "d".to_string(),
+            priority: 1,
+            node_uuid: node_uuid.to_string(),
+            endpoint: "http://localhost".to_string(),
+            version: 1,
+            capabilities: vec![],
+            metadata: std::collections::HashMap::new(),
+            config: std::collections::HashMap::new(),
+            executable: None,
+        }
+    }
+
+    async fn register_and_replay(cfg: SmsConfig) -> i32 {
+        let svc = SmsServiceImpl::new(
+            Arc::new(tokio::sync::RwLock::new(NodeService::new())),
+            Arc::new(ResourceService::new()),
+            Arc::new(cfg),
+        ).await;
+        let node_uuid = uuid::Uuid::new_v4().to_string();
+        let _ = SmsServiceImpl::register_task(&svc, Request::new(make_request(&node_uuid))).await.unwrap();
+        let req = SubscribeTaskEventsRequest { node_uuid, last_event_id: 0 };
+        let mut stream = SmsServiceImpl::subscribe_task_events(&svc, Request::new(req)).await.unwrap().into_inner();
+        let mut count = 0;
+        while let Some(Ok(_ev)) = stream.next().await { count += 1; break; }
+        count
+    }
+
+    #[tokio::test]
+    async fn test_event_kv_memory_independent_from_database() {
+        let mut cfg = SmsConfig::default();
+        cfg.database.db_type = "rocksdb".to_string();
+        cfg.event_kv = Some(KvStoreConfig::memory());
+        let count = register_and_replay(cfg).await;
+        assert!(count >= 1);
+    }
+
+    #[tokio::test]
+    async fn test_event_kv_unsupported_backend_fallback_to_memory() {
+        let mut cfg = SmsConfig::default();
+        cfg.event_kv = Some(KvStoreConfig { backend: "unsupported".to_string(), params: std::collections::HashMap::new() });
+        let count = register_and_replay(cfg).await;
+        assert!(count >= 1);
+    }
+
+    #[tokio::test]
+    async fn test_event_kv_loaded_from_toml() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("sms-config.toml");
+        let content = r#"
+[grpc]
+addr = "127.0.0.1:50051"
+
+[http]
+addr = "127.0.0.1:8080"
+
+[database]
+db_type = "sled"
+path = "./data/sms.db"
+pool_size = 10
+
+[event_kv]
+backend = "memory"
+params = {}
+"#;
+        std::fs::write(&path, content).unwrap();
+        let args = crate::sms::config::CliArgs {
+            config: Some(path.to_string_lossy().to_string()),
+            grpc_addr: None,
+            http_addr: None,
+            db_type: None,
+            db_path: None,
+            db_pool_size: None,
+            enable_swagger: false,
+            disable_swagger: false,
+            enable_web_admin: false,
+            disable_web_admin: false,
+            web_admin_addr: None,
+            log_level: None,
+            heartbeat_timeout: None,
+            cleanup_interval: None,
+            max_upload_bytes: None,
+        };
+        let cfg = crate::sms::config::SmsConfig::load_with_cli(&args).unwrap();
+        assert!(cfg.event_kv.is_some());
+        assert_eq!(cfg.event_kv.as_ref().unwrap().backend, "memory");
+    }
+}

--- a/spear-next/src/sms/services/test_utils.rs
+++ b/spear-next/src/sms/services/test_utils.rs
@@ -158,6 +158,7 @@ impl TestDataGenerator {
             heartbeat_timeout: 90,
             cleanup_interval: 30,
             max_upload_bytes: 64 * 1024 * 1024,
+            event_kv: None,
         }
     }
 
@@ -191,6 +192,7 @@ impl TestDataGenerator {
             heartbeat_timeout: _heartbeat_timeout,
             cleanup_interval: 30,
             max_upload_bytes: 64 * 1024 * 1024,
+            event_kv: None,
         }
     }
 }

--- a/spear-next/src/spearlet/mod.rs
+++ b/spear-next/src/spearlet/mod.rs
@@ -34,6 +34,7 @@ pub mod grpc_server;
 pub mod http_gateway;
 pub mod object_service;
 pub mod registration;
+pub mod task_events;
 
 #[cfg(test)]
 mod config_test;
@@ -55,3 +56,4 @@ pub use grpc_server::{GrpcServer, HealthService};
 pub use http_gateway::HttpGateway;
 pub use object_service::ObjectServiceImpl;
 pub use registration::{RegistrationService, RegistrationState};
+pub use task_events::TaskEventSubscriber;

--- a/spear-next/src/spearlet/task_events.rs
+++ b/spear-next/src/spearlet/task_events.rs
@@ -1,0 +1,109 @@
+use std::{fs, io::Write, path::PathBuf, sync::Arc, time::Duration};
+use tokio::sync::RwLock;
+use tokio_stream::StreamExt;
+use tonic::transport::Channel;
+
+use crate::proto::sms::{task_service_client::TaskServiceClient, SubscribeTaskEventsRequest, TaskEvent, TaskEventKind, GetTaskRequest, Task};
+use crate::spearlet::config::SpearletConfig;
+use tracing::{debug, info, warn};
+
+pub struct TaskEventSubscriber {
+    config: Arc<SpearletConfig>,
+    last_event_id: Arc<RwLock<i64>>, 
+}
+
+impl TaskEventSubscriber {
+    pub fn new(config: Arc<SpearletConfig>) -> Self {
+        let last = Self::load_cursor(&config);
+        Self { config, last_event_id: Arc::new(RwLock::new(last)) }
+    }
+
+    fn compute_node_uuid(cfg: &SpearletConfig) -> String {
+        if let Ok(u) = uuid::Uuid::parse_str(&cfg.node_name) { return u.to_string(); }
+        let base = format!("{}:{}:{}", cfg.grpc.addr.ip(), cfg.grpc.addr.port(), cfg.node_name);
+        uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, base.as_bytes()).to_string()
+    }
+
+    fn cursor_path(cfg: &SpearletConfig) -> PathBuf {
+        let node = Self::compute_node_uuid(cfg);
+        PathBuf::from(&cfg.storage.data_dir).join(format!("task_events_cursor_{}.json", node))
+    }
+
+    fn load_cursor(cfg: &SpearletConfig) -> i64 {
+        let p = Self::cursor_path(cfg);
+        if let Ok(s) = fs::read_to_string(&p) { s.parse::<i64>().unwrap_or(0) } else { 0 }
+    }
+
+    fn store_cursor(cfg: &SpearletConfig, v: i64) {
+        let p = Self::cursor_path(cfg);
+        let _ = fs::create_dir_all(p.parent().unwrap_or(std::path::Path::new(".")));
+        let mut f = fs::File::create(p).unwrap();
+        let _ = write!(f, "{}", v);
+    }
+
+    pub async fn start(self) {
+        let cfg = self.config.clone();
+        let last_event_id = self.last_event_id.clone();
+        tokio::spawn(async move {
+            let node_uuid = Self::compute_node_uuid(&cfg);
+            info!(node_uuid = %node_uuid, sms_addr = %cfg.sms_addr, "TaskEventSubscriber starting");
+            loop {
+                let sms_url = format!("http://{}", cfg.sms_addr);
+                let channel = match Channel::from_shared(sms_url.clone()).unwrap().connect().await { Ok(c)=>c, Err(e)=>{ warn!(error = %e, "SMS channel connect failed, retrying"); tokio::time::sleep(Duration::from_millis(cfg.sms_connect_retry_ms)).await; continue; } };
+                let mut client = TaskServiceClient::new(channel);
+                let last = *last_event_id.read().await;
+                let req = SubscribeTaskEventsRequest { node_uuid: node_uuid.clone(), last_event_id: last };
+                debug!(node_uuid = %node_uuid, last_event_id = last, "Subscribing to task events");
+                let mut stream = match client.subscribe_task_events(req).await { Ok(r)=> r.into_inner(), Err(e)=>{ warn!(error = %e, "SubscribeTaskEvents RPC failed, retrying"); tokio::time::sleep(Duration::from_millis(cfg.sms_connect_retry_ms)).await; continue; } };
+                loop {
+                    match stream.next().await { 
+                        Some(Ok(ev)) => { 
+                            debug!(event_id = ev.event_id, kind = ev.kind, task_id = %ev.task_id, node_uuid = %ev.node_uuid, "Received task event");
+                            *last_event_id.write().await = ev.event_id; 
+                            Self::store_cursor(&cfg, ev.event_id);
+                            Self::handle_event(&cfg, &mut client, ev).await; 
+                        },
+                        Some(Err(e)) => { warn!(error = %e, "Event stream error, reconnecting"); break; },
+                        None => { break; },
+                    }
+                }
+                debug!(delay_ms = cfg.sms_connect_retry_ms, "Reconnect delay before resubscribing");
+                tokio::time::sleep(Duration::from_millis(cfg.sms_connect_retry_ms)).await;
+            }
+        });
+    }
+
+    async fn handle_event(cfg: &SpearletConfig, client: &mut TaskServiceClient<Channel>, ev: TaskEvent) {
+        if ev.node_uuid != Self::compute_node_uuid(cfg) { debug!(event_id = ev.event_id, "Ignoring event for other node"); return; }
+        if ev.kind == TaskEventKind::Create as i32 {
+            debug!(task_id = %ev.task_id, "Fetching task details for execution placeholder");
+            let task = match client.get_task(GetTaskRequest{ task_id: ev.task_id.clone() }).await {
+                Ok(resp) => resp.into_inner().task,
+                Err(_) => None,
+            };
+            Self::execute_task(ev.task_id, task);
+        }
+    }
+
+    fn execute_task(_task_id: String, task: Option<Task>) {
+        if let Some(t) = task {
+            debug!(
+                task_id = %t.task_id,
+                name = %t.name,
+                endpoint = %t.endpoint,
+                status = t.status,
+                priority = t.priority,
+                node_uuid = %t.node_uuid,
+                registered_at = t.registered_at,
+                last_heartbeat = t.last_heartbeat,
+                capabilities_count = t.capabilities.len(),
+                metadata_count = t.metadata.len(),
+                "Task details"
+            );
+        } else {
+            debug!(task_id = %_task_id, "Task details unavailable");
+        }
+        info!(task_id = %_task_id, "Executing task placeholder (TODO)");
+        todo!("Implement task execution dispatch");
+    }
+}

--- a/spear-next/src/spearlet/task_events_test.rs
+++ b/spear-next/src/spearlet/task_events_test.rs
@@ -1,0 +1,37 @@
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use tempfile::tempdir;
+    use crate::spearlet::config::{SpearletConfig, HttpConfig, StorageConfig};
+    use crate::spearlet::task_events::TaskEventSubscriber;
+
+    fn tmp_cfg() -> Arc<SpearletConfig> {
+        let dir = tempdir().unwrap();
+        let p = dir.path().to_string_lossy().to_string();
+        Arc::new(SpearletConfig {
+            node_name: "test-node".to_string(),
+            grpc: crate::config::base::ServerConfig { addr: "127.0.0.1:50052".parse().unwrap(), ..Default::default() },
+            http: HttpConfig { server: crate::config::base::ServerConfig { addr: "127.0.0.1:8081".parse().unwrap(), ..Default::default() } },
+            storage: StorageConfig { backend: "memory".to_string(), data_dir: p, max_cache_size_mb: 16, compression_enabled: false, max_object_size: 1024*1024 },
+            logging: crate::config::base::LogConfig::default(),
+            sms_addr: "127.0.0.1:50051".to_string(),
+            auto_register: false,
+            heartbeat_interval: 5,
+            cleanup_interval: 60,
+            sms_connect_timeout_ms: 1000,
+            sms_connect_retry_ms: 200,
+            reconnect_total_timeout_ms: 2000,
+        })
+    }
+
+    #[test]
+    fn test_cursor_store_roundtrip() {
+        let cfg = tmp_cfg();
+        let sub = TaskEventSubscriber::new(cfg.clone());
+        TaskEventSubscriber::store_cursor(&cfg, 42);
+        let v = TaskEventSubscriber::load_cursor(&cfg);
+        assert_eq!(v, 42);
+        drop(sub);
+    }
+}
+


### PR DESCRIPTION
This pull request introduces a new task event system to the SMS service, enabling durable event publishing and subscription for task lifecycle changes (create, update, cancel). It adds configuration options for storing task events in various KV backends, implements the event bus logic, exposes new gRPC APIs for event subscription, and integrates event publishing into existing task operations. The changes also include tests for the event bus and configuration updates to support the new feature.

**Task Event System Implementation**

* Added the `TaskEventBus` in `spear-next/src/sms/events.rs` to handle durable publishing, replay, and broadcast of task events using a configurable KV backend.
* Integrated event publishing into the task registration flow in `SmsServiceImpl`, ensuring a create event is published when a task is registered.
* Implemented the `SubscribeTaskEvents` gRPC method, allowing clients to replay missed events and receive live updates for a given node. [[1]](diffhunk://#diff-ed2409e6616a7b8b6dd0a46bf70c40fcf104311ca07e506c8135a2278b4bdb4eR647-R676) [[2]](diffhunk://#diff-04aed03b9a090d68c7ff6aacf0b3bf4c445365482e71119d0f419c2c9a88d15dR161-R163)
* Added unit tests for the event bus covering publish/subscribe and replay functionality.

**Configuration and Proto Changes**

* Extended configuration files and struct (`config.toml`, `config-sled.toml`, `config-rocksdb.toml`, etc.) to support an `[event_kv]` section specifying the backend and parameters for event storage. [[1]](diffhunk://#diff-eca72507ef6788a26cd91d39d2f7adff498f7cb518db2deccce5caa7accc516fR43-R46) [[2]](diffhunk://#diff-70c38e889dda38e622e77243ec79db48cbb775f722c14dd77aca10cef6198d29R23-R26) [[3]](diffhunk://#diff-49124490c907555d930bc6cf219d4d80f9dc11628f5b581e32ee82288034f5afR23-R26) [[4]](diffhunk://#diff-5e30e23a5c17dd50092213de1536578dcfa7cbfff7ea9d2af1fcae6bba93546aR23-R26) [[5]](diffhunk://#diff-ba76d638ef052b1d88539db37757483ba0a0b91446802d1a5a2355a24a037fc2R103-R104)
* Updated proto definitions in `task.proto` to include `TaskEventKind`, `TaskEvent`, and `SubscribeTaskEventsRequest` messages, and exposed the `SubscribeTaskEvents` RPC. [[1]](diffhunk://#diff-04aed03b9a090d68c7ff6aacf0b3bf4c445365482e71119d0f419c2c9a88d15dR83-R108) [[2]](diffhunk://#diff-04aed03b9a090d68c7ff6aacf0b3bf4c445365482e71119d0f419c2c9a88d15dR161-R163)

**Service and App Integration**

* Updated `SmsServiceImpl` to initialize the event bus with the configured KV backend, supporting independent configuration from the main database. [[1]](diffhunk://#diff-ed2409e6616a7b8b6dd0a46bf70c40fcf104311ca07e506c8135a2278b4bdb4eR70-R87) [[2]](diffhunk://#diff-ed2409e6616a7b8b6dd0a46bf70c40fcf104311ca07e506c8135a2278b4bdb4eR58)
* Started a task event subscriber in the spearlet app to support event handling.

**Codebase Organization**

* Added mod imports and test module for events in `spear-next/src/sms/mod.rs` for better code organization and testability. [[1]](diffhunk://#diff-8e674e85b57b92b1602223953746b0d73fc04adf6268a6c39cda2911361230d5R49) [[2]](diffhunk://#diff-8e674e85b57b92b1602223953746b0d73fc04adf6268a6c39cda2911361230d5R67-R68)