### PR TITLE
update task event related documents

### DIFF
--- a/spear-next/README.md
+++ b/spear-next/README.md
@@ -376,6 +376,25 @@ make run-spearlet
 cargo run --bin spearlet -- --sms-addr 127.0.0.1:50051 --auto-register
 ```
 
+### Task Events Subscription / 任务事件订阅
+
+- SPEARlet 通过 gRPC 订阅 SMS 的任务事件流，仅处理当前节点的事件。
+- 订阅器在 `storage.data_dir` 下持久化事件游标，文件名：`task_events_cursor_{node_uuid}.json`。
+- 支持自动重连与退避：`sms_connect_retry_ms` 控制重试间隔，`sms_connect_timeout_ms` 控制连接超时，`reconnect_total_timeout_ms` 控制断线后的总超时。
+- 对 `Create` 事件会拉取任务详情并准备执行分发（当前为占位逻辑）。
+
+Usage / 使用示例：
+```rust
+use std::sync::Arc;
+use spear_next::spearlet::{config::SpearletConfig, task_events::TaskEventSubscriber};
+
+let config = Arc::new(SpearletConfig::default());
+let subscriber = TaskEventSubscriber::new(config.clone());
+subscriber.start().await; // 后台运行
+```
+
+Docs / 文档：`ai-docs/task-events-subscriber-en.md`、`ai-docs/task-events-subscriber-zh.md`
+
 #### Docker Support / Docker支持
 
 A Dockerfile will be provided for containerized deployment.

--- a/spear-next/ai-docs/INDEX.md
+++ b/spear-next/ai-docs/INDEX.md
@@ -30,6 +30,7 @@
 | Task Service Optimization | [task-service-optimization-en.md](./task-service-optimization-en.md) | [task-service-optimization-zh.md](./task-service-optimization-zh.md) | Task服务优化文档 |
 | Resource Service Refactoring | [resource-service-refactoring-en.md](./resource-service-refactoring-en.md) | [resource-service-refactoring-zh.md](./resource-service-refactoring-zh.md) | 资源服务代码重构指南 |
 | Config Service Refactoring | [config-service-refactoring-en.md](./config-service-refactoring-en.md) | [config-service-refactoring-zh.md](./config-service-refactoring-zh.md) | 配置服务代码重构指南 |
+| Task Events Subscriber | [task-events-subscriber-en.md](./task-events-subscriber-en.md) | [task-events-subscriber-zh.md](./task-events-subscriber-zh.md) | 任务事件订阅器设计与实现 |
 
 ### 🚀 Runtime Layer / 运行时层
 

--- a/spear-next/ai-docs/task-events-subscriber-en.md
+++ b/spear-next/ai-docs/task-events-subscriber-en.md
@@ -1,0 +1,86 @@
+# Task Events Subscriber
+
+## Overview
+
+SPEARlet includes a streaming Task Events subscriber that connects to the SMS `TaskService` and listens for task lifecycle events specific to the current node. It persists a cursor to ensure exactly-once processing across restarts and handles automatic reconnection with configurable backoff.
+
+## Components
+
+- `TaskEventSubscriber`: Maintains configuration and the last processed event ID cursor.
+- Node UUID derivation: Uses `node_name` if it is a valid UUID; otherwise derives a stable UUIDv5 from `grpc.addr`, `grpc.port`, and `node_name`.
+- Cursor persistence: Stores `last_event_id` under `storage.data_dir` with filename pattern `task_events_cursor_{node_uuid}.json`.
+
+## Key Behaviors
+
+- Connects to SMS via `sms_addr` using gRPC and subscribes to `SubscribeTaskEvents` with `node_uuid` and `last_event_id`.
+- Streams events; on each event:
+  - Updates `last_event_id` in memory and persists to disk.
+  - For `Create` events, fetches task details via `GetTask` and prepares for execution dispatch (placeholder `todo!`).
+- Ignores events not targeted to the current node.
+- Automatically reconnects on stream or connection errors, waiting `sms_connect_retry_ms` between attempts.
+
+## Configuration
+
+Relevant `SpearletConfig` fields:
+
+```toml
+[spearlet]
+node_name = "spearlet-node"
+sms_addr = "127.0.0.1:50051"
+auto_register = true
+heartbeat_interval = 30
+cleanup_interval = 300
+sms_connect_timeout_ms = 15000
+sms_connect_retry_ms = 500
+reconnect_total_timeout_ms = 300000
+
+[spearlet.grpc]
+addr = "0.0.0.0:50052"
+
+[spearlet.http]
+cors_enabled = true
+swagger_enabled = true
+
+[spearlet.storage]
+backend = "memory"
+data_dir = "./data/spearlet"
+```
+
+Environment variables supported: `SPEARLET_SMS_ADDR`, `SPEARLET_SMS_CONNECT_TIMEOUT_MS`, `SPEARLET_SMS_CONNECT_RETRY_MS`, `SPEARLET_RECONNECT_TOTAL_TIMEOUT_MS`, `SPEARLET_STORAGE_DATA_DIR`.
+
+## Usage
+
+Start the subscriber during SPEARlet initialization:
+
+```rust
+use std::sync::Arc;
+use spear_next::spearlet::{config::SpearletConfig, task_events::TaskEventSubscriber};
+
+let config = Arc::new(SpearletConfig::default());
+let subscriber = TaskEventSubscriber::new(config.clone());
+subscriber.start().await; // runs in background
+```
+
+The subscriber persists a cursor to `storage.data_dir`, enabling resubscription from the last processed event after restart.
+
+## Error Handling & Resilience
+
+- Retries connection on failure with `sms_connect_retry_ms` delay.
+- Handles stream errors gracefully, resubscribing after delay.
+- Validates `node_uuid` to ensure only node-targeted events are processed.
+- Cursor file directory is created on demand if missing.
+
+## Testing
+
+- Cursor roundtrip test: `src/spearlet/task_events_test.rs` verifies `store_cursor` and `load_cursor` behavior.
+- Integration tests should simulate SMS event streaming and reconnection scenarios.
+
+## Code References
+
+- `src/spearlet/task_events.rs:44` — subscriber startup and reconnect loop
+- `src/spearlet/task_events.rs:76` — event handling and task fetch on Create
+- `src/spearlet/config.rs:259` — default configuration values
+
+---
+
+This document ensures alignment of documentation with the latest Task Events subscriber implementation.

--- a/spear-next/ai-docs/task-events-subscriber-zh.md
+++ b/spear-next/ai-docs/task-events-subscriber-zh.md
@@ -1,0 +1,86 @@
+# 任务事件订阅器
+
+## 概述
+
+SPEARlet 内置任务事件订阅器，通过连接 SMS 的 `TaskService` 订阅与当前节点相关的任务生命周期事件。订阅器将游标持久化以保证重启后能继续处理（近似一次性处理），并支持可配置的自动重连与退避。
+
+## 组件
+
+- `TaskEventSubscriber`：维护配置与最后处理的事件 ID 游标。
+- 节点 UUID 推导：当 `node_name` 是合法 UUID 时直接使用；否则基于 `grpc.addr`、`grpc.port` 与 `node_name` 通过 UUIDv5 派生稳定的 UUID。
+- 游标持久化：将 `last_event_id` 存储在 `storage.data_dir` 下，文件名为 `task_events_cursor_{node_uuid}.json`。
+
+## 核心行为
+
+- 通过 `sms_addr` 使用 gRPC 连接 SMS，携带 `node_uuid` 与 `last_event_id` 调用 `SubscribeTaskEvents`。
+- 事件流处理：每收到事件时——
+  - 更新内存中的 `last_event_id` 并写入持久化文件。
+  - 对 `Create` 事件，调用 `GetTask` 获取任务详情，并为后续执行分发做准备（当前为 `todo!` 占位）。
+- 忽略不属于当前节点的事件。
+- 在连接或流错误时自动重连，等待时间由 `sms_connect_retry_ms` 控制。
+
+## 配置
+
+相关 `SpearletConfig` 字段：
+
+```toml
+[spearlet]
+node_name = "spearlet-node"
+sms_addr = "127.0.0.1:50051"
+auto_register = true
+heartbeat_interval = 30
+cleanup_interval = 300
+sms_connect_timeout_ms = 15000
+sms_connect_retry_ms = 500
+reconnect_total_timeout_ms = 300000
+
+[spearlet.grpc]
+addr = "0.0.0.0:50052"
+
+[spearlet.http]
+cors_enabled = true
+swagger_enabled = true
+
+[spearlet.storage]
+backend = "memory"
+data_dir = "./data/spearlet"
+```
+
+支持的环境变量：`SPEARLET_SMS_ADDR`、`SPEARLET_SMS_CONNECT_TIMEOUT_MS`、`SPEARLET_SMS_CONNECT_RETRY_MS`、`SPEARLET_RECONNECT_TOTAL_TIMEOUT_MS`、`SPEARLET_STORAGE_DATA_DIR`。
+
+## 使用方式
+
+在 SPEARlet 初始化阶段启动订阅器：
+
+```rust
+use std::sync::Arc;
+use spear_next::spearlet::{config::SpearletConfig, task_events::TaskEventSubscriber};
+
+let config = Arc::new(SpearletConfig::default());
+let subscriber = TaskEventSubscriber::new(config.clone());
+subscriber.start().await; // 后台运行
+```
+
+订阅器将游标持久化到 `storage.data_dir` 中，SPEARlet 重启后可以从最后处理的事件续订。
+
+## 错误处理与韧性
+
+- 连接失败时按 `sms_connect_retry_ms` 延迟重试。
+- 优雅处理流错误，延迟后重新订阅。
+- 校验 `node_uuid`，仅处理当前节点目标事件。
+- 游标文件目录若不存在会自动创建。
+
+## 测试
+
+- 游标读写回路测试：`src/spearlet/task_events_test.rs` 验证 `store_cursor`/`load_cursor` 行为。
+- 建议的集成测试：模拟 SMS 事件流与重连场景。
+
+## 代码引用
+
+- `src/spearlet/task_events.rs:44` — 订阅器启动与重连循环
+- `src/spearlet/task_events.rs:76` — 事件处理与 `Create` 事件任务详情获取
+- `src/spearlet/config.rs:259` — 默认配置值
+
+---
+
+本文档与任务事件订阅器的最新实现保持一致，便于后续扩展与维护。


### PR DESCRIPTION
This pull request introduces comprehensive documentation and usage examples for the new Task Events Subscriber feature in SPEARlet. The changes provide both English and Chinese guides, update the documentation index, and add a dedicated section to the README describing how the subscriber works, its configuration, and usage.

**Documentation and Usage Guides:**

* Added detailed English documentation for the Task Events Subscriber, covering its architecture, configuration, usage, error handling, and testing. (`ai-docs/task-events-subscriber-en.md`)
* Added a Chinese version of the Task Events Subscriber documentation with equivalent details for native readers. (`ai-docs/task-events-subscriber-zh.md`)
* Updated the documentation index to include links to both the English and Chinese Task Events Subscriber docs. (`ai-docs/INDEX.md`)

**README and Example Usage:**

* Added a new section to the README describing the Task Events Subscription feature, its persistence and reconnection logic, and provided a Rust code example for initializing and starting the subscriber. (`spear-next/README.md`)